### PR TITLE
Create visitors for block, extend, and include tags

### DIFF
--- a/jinja2schema/config.py
+++ b/jinja2schema/config.py
@@ -31,10 +31,28 @@ class Config(object):
     unknown structure. If this variable is set, ``xs`` will be a boolean.
     """
 
+    PACKAGE_NAME = ''
+    """Name of the package where you want to load templates from.
+
+    This configuration is for if you are using includes in your jinja templates. This tells jinja
+    where to look to be able to load the included template from. If you do not plan on using ``includes``
+    this configuration is not needed.
+    """
+
+    TEMPLATE_DIR = 'templates'
+    """Name of the directory where you want to load templates from. Defaulted to ``templates``
+
+    This configuration is for if you are using includes in your jinja templates. This tells jinja
+    which directoy to look to be able to load the included template from. If you do not plan on using ``includes``
+    this configuration is not needed.
+    """
+
     def __init__(self,
                  TYPE_OF_VARIABLE_INDEXED_WITH_VARIABLE_TYPE='dictionary',
                  TYPE_OF_VARIABLE_INDEXED_WITH_INTEGER_TYPE='list',
-                 BOOLEAN_CONDITIONS=False):
+                 BOOLEAN_CONDITIONS=False,
+                 PACKAGE_NAME='',
+                 TEMPLATE_DIR='templates'):
         if TYPE_OF_VARIABLE_INDEXED_WITH_VARIABLE_TYPE not in ('dictionary', 'list'):
             raise ValueError('TYPE_OF_VARIABLE_INDEXED_WITH_VARIABLE_TYPE must be'
                              'either "dictionary" or "list"')
@@ -44,6 +62,8 @@ class Config(object):
         self.TYPE_OF_VARIABLE_INDEXED_WITH_INTEGER_TYPE = TYPE_OF_VARIABLE_INDEXED_WITH_INTEGER_TYPE
         self.TYPE_OF_VARIABLE_INDEXED_WITH_VARIABLE_TYPE = TYPE_OF_VARIABLE_INDEXED_WITH_VARIABLE_TYPE
         self.BOOLEAN_CONDITIONS = BOOLEAN_CONDITIONS
+        self.PACKAGE_NAME = PACKAGE_NAME
+        self.TEMPLATE_DIR = TEMPLATE_DIR
 
 
 default_config = Config()

--- a/jinja2schema/visitors/stmt.py
+++ b/jinja2schema/visitors/stmt.py
@@ -190,6 +190,13 @@ def visit_macro(ast, macroses=None, config=default_config):
     return body_struct
 
 
+@visits_stmt(nodes.Include)
+def visit_include(ast, macroses=None, config=default_config):
+    env = Environment(loader=PackageLoader(config.PACKAGE_NAME, config.TEMPLATE_DIR))
+    template = env.parse(env.loader.get_source(env, ast.template.value)[0])
+    return visit_many(template.body, macroses, config)
+
+
 @visits_stmt(nodes.Block)
 def visit_block(ast, macroses=None, config=default_config):
     return visit_many(ast.body, macroses, config)

--- a/jinja2schema/visitors/stmt.py
+++ b/jinja2schema/visitors/stmt.py
@@ -188,3 +188,8 @@ def visit_macro(ast, macroses=None, config=default_config):
     for arg in args_struct.iterkeys():
         body_struct.pop(arg, None)
     return body_struct
+
+
+@visits_stmt(nodes.Block)
+def visit_block(ast, macroses=None, config=default_config):
+    return visit_many(ast.body, macroses, config)

--- a/jinja2schema/visitors/stmt.py
+++ b/jinja2schema/visitors/stmt.py
@@ -197,6 +197,13 @@ def visit_include(ast, macroses=None, config=default_config):
     return visit_many(template.body, macroses, config)
 
 
+@visits_stmt(nodes.Extends)
+def visit_extends(ast, macroses=None, config=default_config):
+    env = Environment(loader=PackageLoader(config.PACKAGE_NAME, config.TEMPLATE_DIR))
+    template = env.parse(env.loader.get_source(env, ast.template.value)[0])
+    return visit_many(template.body, macroses, config)
+
+
 @visits_stmt(nodes.Block)
 def visit_block(ast, macroses=None, config=default_config):
     return visit_many(ast.body, macroses, config)

--- a/jinja2schema/visitors/stmt.py
+++ b/jinja2schema/visitors/stmt.py
@@ -8,14 +8,14 @@ Statement visitors return :class:`.models.Dictionary` of structures of variables
 """
 import functools
 
-from jinja2 import nodes
+from jinja2 import nodes, Environment, PackageLoader
 from jinja2schema.config import default_config
 
 from ..model import Scalar, Dictionary, List, Unknown, Tuple, Boolean
 from ..macro import Macro
 from ..mergers import merge, merge_many
 from ..exceptions import InvalidExpression
-from .. import _compat
+from .._compat import iteritems, izip, zip_longest
 from .expr import Context, visit_expr
 from .util import visit_many
 
@@ -46,7 +46,7 @@ def visit_stmt(ast, macroses=None, config=default_config):
     """
     visitor = stmt_visitors.get(type(ast))
     if not visitor:
-        for node_cls, visitor_ in stmt_visitors.iteritems():
+        for node_cls, visitor_ in iteritems(stmt_visitors):
             if isinstance(ast, node_cls):
                 visitor = visitor_
     if not visitor:
@@ -95,7 +95,7 @@ def visit_if(ast, macroses=None, config=default_config):
     else_struct = visit_many(ast.else_, macroses, config, predicted_struct_cls=Scalar) if ast.else_ else Dictionary()
     struct = merge_many(test_struct, if_struct, else_struct)
 
-    for var_name, var_struct in test_struct.iteritems():
+    for var_name, var_struct in iteritems(test_struct):
         if var_struct.checked_as_defined or var_struct.checked_as_undefined:
             if var_struct.checked_as_undefined:
                 lookup_struct = if_struct
@@ -125,7 +125,7 @@ def visit_assign(ast, macroses=None, config=default_config):
             if len(ast.target.items) != len(ast.node.items):
                 raise InvalidExpression(ast, 'number of items in left side is different '
                                              'from right side')
-            for name_ast, var_ast in _compat.izip(ast.target.items, ast.node.items):
+            for name_ast, var_ast in izip(ast.target.items, ast.node.items):
                 variables.append((name_ast.name, var_ast))
         for var_name, var_ast in variables:
             var_rtype, var_struct = visit_expr(var_ast, Context(predicted_struct=Unknown.from_ast(var_ast)), macroses, config)
@@ -160,7 +160,7 @@ def visit_macro(ast, macroses=None, config=default_config):
     kwargs = []
     body_struct = visit_many(ast.body, macroses, config, predicted_struct_cls=Scalar)
 
-    for i, (arg, default_value_ast) in enumerate(reversed(list(_compat.zip_longest(reversed(ast.args),
+    for i, (arg, default_value_ast) in enumerate(reversed(list(zip_longest(reversed(ast.args),
                                                                            reversed(ast.defaults)))), start=1):
         has_default_value = bool(default_value_ast)
         if has_default_value:


### PR DESCRIPTION
After attempting to create a schema for a template with an include tag I found that there was no current support for such a thing currently. Further research showed that this was the case for extend and block as well. 

These commits create a bit of further configuration options if includes or extends wish to be used. I could not find a way to get around this. If there is way to do this that I am not aware of, let me know and I will update the PR.