### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ License
 .. _Jinja2: http://jinja.pocoo.org/docs/
 .. _Demo: http://jinja2schema.aromanovich.ru/
 .. _demo page: http://jinja2schema.aromanovich.ru/
-.. _Documentation: http://jinja2schema.rtfd.org/
+.. _Documentation: https://jinja2schema.readthedocs.io/
 .. _GitHub: https://github.com/aromanovich/jinja2schema
 .. _PyPI: https://pypi.python.org/pypi/jinja2schema
 .. _BSD license: https://github.com/aromanovich/jinja2schema/blob/master/LICENSE

--- a/jinja2schema/__init__.py
+++ b/jinja2schema/__init__.py
@@ -6,7 +6,7 @@ jinja2schema
 
 Type inference for Jinja2 templates.
 
-See http://jinja2schema.rtfd.org/ for documentation.
+See https://jinja2schema.readthedocs.io/ for documentation.
 
 :copyright: (c) 2014 Anton Romanovich
 :license: BSD

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license=open('LICENSE').read(),
     author='Anton Romanovich',
     author_email='anthony.romanovich@gmail.com',
-    url='https://jinja2schema.readthedocs.org',
+    url='https://jinja2schema.readthedocs.io',
     packages=find_packages(exclude=['tests']),
     install_requires=['Jinja2>=2.2'],
     classifiers=[


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
